### PR TITLE
Add Rollup and first, second, third query methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 yarn.lock
 /node_modules
+dist

--- a/package.json
+++ b/package.json
@@ -2,22 +2,26 @@
   "name": "generation",
   "version": "0.1.0",
   "description": "A library for transforming generators and iterators",
-  "main": "nodule.js",
-  "module": "index.js",
+  "main": "dist/index.cjs.js",
+  "module": "dist/index.esm.js",
   "repository": "https://github.com/cowboyd/generation",
   "author": "Charles Lowell <cowboyd@frontside.io>",
   "license": "MIT",
   "private": false,
   "scripts": {
+    "build": "rollup --config",
     "test": "mocha --recursive -r tests/setup tests"
   },
   "devDependencies": {
-    "@babel/core": "^7.0.0-beta.55",
-    "@babel/plugin-proposal-class-properties": "^7.0.0-beta.55",
-    "@babel/preset-env": "^7.0.0-beta.55",
-    "@babel/register": "^7.0.0-beta.55",
+    "@babel/core": "7.0.0-beta.55",
+    "@babel/plugin-proposal-class-properties": "7.0.0-beta.55",
+    "@babel/preset-env": "7.0.0-beta.55",
+    "@babel/register": "7.0.0-beta.55",
     "expect": "^23.4.0",
     "mocha": "^5.2.0",
-    "regenerator-runtime": "^0.12.0"
+    "regenerator-runtime": "^0.12.0",
+    "rollup": "^0.64.1",
+    "rollup-plugin-babel": "^4.0.0-beta.0",
+    "rollup-plugin-node-resolve": "^3.3.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,61 @@
+const pkg = require("./package.json");
+const babel = require("rollup-plugin-babel");
+const resolve = require("rollup-plugin-node-resolve");
+
+const babelPlugin = babel({
+  babelrc: false,
+  comments: false,
+  plugins: ["@babel/plugin-proposal-class-properties"],
+  presets: [
+    [
+      "@babel/preset-env",
+      {
+        modules: false
+      }
+    ]
+  ]
+});
+
+//const fileSize = filesize();
+
+module.exports = [
+  {
+    input: "index.js",
+    //external,
+    output: {
+      file: pkg.main,
+      format: "cjs",
+      sourcemap: true
+    },
+    plugins: [
+      resolve(),
+      babel({
+        babelrc: false,
+        comments: false,
+        plugins: ["@babel/plugin-proposal-class-properties"],
+        presets: [
+          [
+            "@babel/preset-env",
+            {
+              targets: {
+                node: "6"
+              },
+              modules: false
+            }
+          ]
+        ]
+      }),
+      //fileSize
+    ]
+  },
+  {
+    input: "index.js",
+    //external,
+    output: { file: pkg.module, format: "es", sourcemap: true },
+    plugins: [
+      resolve(),
+      babelPlugin,
+      //fileSize
+    ]
+  }
+];

--- a/src/query.js
+++ b/src/query.js
@@ -10,6 +10,21 @@ export default class Query {
     return this.length;
   }
 
+  get first() {
+    let [first] = this;
+    return first;
+  }
+
+  get second() {
+    let [,second] = this;
+    return second;
+  }
+
+  get third() {
+    let [,,third] = this;
+    return third;
+  }
+
   recompute() {
     let next = new Query(this.generator);
     if (!this.isReified || this.equals(next)) {


### PR DESCRIPTION
## Purpose

Adds a rollup bundle so that consuming packages do not have to compile this library themselves.

Also adds `first`, `second`, and `third` query methods.

### Todo

- [ ] Test new query methods